### PR TITLE
Improvements

### DIFF
--- a/src/algorithms/algorithm.py
+++ b/src/algorithms/algorithm.py
@@ -1,4 +1,4 @@
-from direct.stdpy.threading import Condition
+from utility.threading import Condition
 from typing import Optional, List
 from abc import ABC, abstractmethod
 

--- a/src/algorithms/algorithm.py
+++ b/src/algorithms/algorithm.py
@@ -1,4 +1,4 @@
-from threading import Condition
+from direct.stdpy.threading import Condition
 from typing import Optional, List
 from abc import ABC, abstractmethod
 

--- a/src/algorithms/basic_testing.py
+++ b/src/algorithms/basic_testing.py
@@ -119,8 +119,10 @@ class BasicTesting:
                 with self.cv:
                     self.requires_key_frame = True
                     self.cv.notify()
-                    cond_var_wait_for(self.cv, sleep_pred, timeout=sleep_dt)
-                sleep_dt = sleep_dt - time.time() + t
+                    cond_var_wait_for(self.cv, sleep_pred)
+                nt = time.time()
+                sleep_dt = sleep_dt - nt + t
+                t = nt
 
         if self.is_terminated():
             from simulator.models.map_model import AlgorithmTerminated

--- a/src/algorithms/basic_testing.py
+++ b/src/algorithms/basic_testing.py
@@ -1,4 +1,3 @@
-from direct.stdpy.threading import Condition
 from typing import Dict, Any, List, Callable, Optional
 from operator import mul
 from functools import reduce
@@ -7,6 +6,7 @@ import time
 import numpy as np
 from structures.heap import Heap
 
+from utility.threading import Condition, cond_var_wait_for
 from algorithms.configuration.entities.agent import Agent
 from algorithms.configuration.entities.trace import Trace
 from algorithms.configuration.entities.obstacle import Obstacle
@@ -18,7 +18,6 @@ from simulator.services.services import Services
 from simulator.services.timer import Timer
 from simulator.views.map.display.map_display import MapDisplay
 from structures import Size, Point
-from utility.misc import cond_var_wait_for
 
 
 class BasicTesting:

--- a/src/algorithms/basic_testing.py
+++ b/src/algorithms/basic_testing.py
@@ -1,4 +1,4 @@
-from threading import Condition
+from direct.stdpy.threading import Condition
 from typing import Dict, Any, List, Callable, Optional
 from operator import mul
 from functools import reduce
@@ -17,6 +17,7 @@ from simulator.services.services import Services
 from simulator.services.timer import Timer
 from simulator.views.map.display.map_display import MapDisplay
 from structures import Size, Point
+from utility.misc import cond_var_wait_for
 
 
 class BasicTesting:
@@ -96,7 +97,7 @@ class BasicTesting:
                 with self.cv:
                     self.requires_key_frame = True
                     self.cv.notify()
-                    self.cv.wait_for(lambda: not self.requires_key_frame or self.is_terminated())
+                    cond_var_wait_for(self.cv, lambda: not self.requires_key_frame or self.is_terminated())
             self.key_frame_skip_count = 0
         else:
             self.key_frame_skip_count += 1

--- a/src/algorithms/lstm/a_star_waypoint.py
+++ b/src/algorithms/lstm/a_star_waypoint.py
@@ -137,10 +137,9 @@ class WayPointNavigation(Algorithm):
         local_kernel_algo.find_path(agent_pos=self.way_points[-1], goal_pos=self._get_grid().goal.position)
         local_kernel_algo.map.replay_trace(lambda m: self.__replay(m))
         self.__accumulate_space(local_kernel_algo)
-        self.key_frame()
         self.__local_kernel_anim = None
         self.__global_kernel_anim = None
-        self.key_frame()
+        self.key_frame(True)
 
     def __update_map(self, local_kernel_algo, global_kernel_algo):
         if isinstance(self._get_grid(), RosMap):

--- a/src/algorithms/lstm/combined_online_LSTM.py
+++ b/src/algorithms/lstm/combined_online_LSTM.py
@@ -1,5 +1,5 @@
 import copy
-from threading import Thread
+from direct.stdpy.threading import Thread
 from typing import List, Tuple, Optional, Set
 
 from algorithms.algorithm import Algorithm

--- a/src/algorithms/lstm/combined_online_LSTM.py
+++ b/src/algorithms/lstm/combined_online_LSTM.py
@@ -1,5 +1,5 @@
 import copy
-from direct.stdpy.threading import Thread
+from utility.threading import Thread
 from typing import List, Tuple, Optional, Set
 
 from algorithms.algorithm import Algorithm

--- a/src/algorithms/lstm/combined_online_LSTM.py
+++ b/src/algorithms/lstm/combined_online_LSTM.py
@@ -26,7 +26,7 @@ class CombinedOnlineLSTM(Algorithm):
                  max_it: float = float('inf'), threaded: bool = False):
         super().__init__(services, testing)
 
-        if not self.kernel_names:
+        if not kernel_names:
             self.kernel_names = [
                 "tile_by_tile_training_house_10_model",
                 "tile_by_tile_training_house_100_model",

--- a/src/batch_train.sh
+++ b/src/batch_train.sh
@@ -4,4 +4,4 @@
 module load anaconda3/personal
 
 pip3 install -r $HOME/projects/PathBench/requirements.txt
-python3 $HOME/projects/PathBench/src/runtrainer.py -n 30 -f
+python3 $HOME/projects/PathBench/src/run_trainer.py -n 30 -f

--- a/src/main.py
+++ b/src/main.py
@@ -107,7 +107,7 @@ def main() -> bool:
     parser.add_argument("-v", "--visualiser", action='store_true', help="run simulator with graphics")
     parser.add_argument("-g", "--generator", action='store_true', help="run generator")
     parser.add_argument("-t", "--trainer", action='store_true', help="runs model trainer")
-    parser.add_argument("-d", "--debug", choices=['NONE', 'BASIC', 'LOW', 'MEDIUM', 'HIGH'], default='HIGH', help="set the debug level when running, default is high")
+    parser.add_argument("-d", "--debug", choices=['NONE', 'BASIC', 'LOW', 'MEDIUM', 'HIGH'], default='LOW', help="set the debug level when running, default is low")
     parser.add_argument("-V", dest="visualiser_flags", metavar="VISUALISER_FLAG", action='append',
                         help="Visualiser options (overriding Panda3D's default Config.prc - see https://docs.panda3d.org/1.10/python/programming/configuration/configuring-panda3d#configuring-panda3d for options [windowed-fullscreen is an additional custom option])")
 

--- a/src/ros/gazebo/ros.py
+++ b/src/ros/gazebo/ros.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from threading import Lock, Condition
 
 import numpy as np
 import cv2 as cv

--- a/src/ros/ogm_subscriber/ros.py
+++ b/src/ros/ogm_subscriber/ros.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from threading import Lock, Condition
 from typing import Optional
 
 import numpy as np

--- a/src/run_trainer.py
+++ b/src/run_trainer.py
@@ -43,7 +43,7 @@ from algorithms.classic.testing.way_point_navigation_testing import WayPointNavi
 
 import argparse
 
-parser = argparse.ArgumentParser(prog="runtrainer.py",
+parser = argparse.ArgumentParser(prog="run_trainer.py",
                                  description="PathBench trainer runner",
                                  formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument('-n', '--num_maps', type=int, default=100, help="number of maps to generate for the trainer")

--- a/src/simulator/models/map_model.py
+++ b/src/simulator/models/map_model.py
@@ -1,6 +1,6 @@
-from direct.stdpy.threading import Thread, Condition
 import time
 
+from utility.threading import Thread, Condition, cond_var_wait_for
 from algorithms.configuration.maps.dense_map import DenseMap
 from algorithms.configuration.maps.sparse_map import SparseMap
 from simulator.models.model import Model
@@ -11,7 +11,6 @@ from simulator.services.event_manager.events.key_frame_event import KeyFrameEven
 from simulator.services.services import Services
 from simulator.services.timer import Timer
 from structures import Point
-from utility.misc import cond_var_wait_for
 
 class AlgorithmTerminated(Exception):
     pass
@@ -150,11 +149,11 @@ class MapModel(Model):
         else:
             self._services.debug.write("Map conversion not applicable", DebugLevel.BASIC)
             return
-        
+
         if mp is None:
             self._services.debug.write("Map conversion not applicable", DebugLevel.BASIC)
             return
-        
+
         self.reset()
         timer: Timer = Timer()
         self._services.algorithm.map = mp

--- a/src/simulator/services/algorithm_runner.py
+++ b/src/simulator/services/algorithm_runner.py
@@ -1,5 +1,4 @@
 import copy
-from threading import Condition
 from typing import Optional, Type, TYPE_CHECKING, List, Any, Tuple, Dict
 
 from algorithms.configuration.configuration import Configuration

--- a/src/simulator/services/graphics/renderer.py
+++ b/src/simulator/services/graphics/renderer.py
@@ -10,14 +10,16 @@ class Renderer():
     __roots: List[NodePath]
     __draw_nps: List[NodePath]
     __circles: List[Tuple[int, float, Geom]]
+    __thicknesses: List[float]
     __line_segs: LineSegs
 
     def __init__(self, root: NodePath) -> None:
         self.__roots = [root]
         self.__draw_nps = []
         self.__circles = []
+        self.__thicknesses = [2.5]
         self.__line_segs = LineSegs()
-        self.__line_segs.set_thickness(4)
+        self.__line_segs.set_thickness(2.5)
 
     def push_root(self, np: NodePath) -> None:
         assert isinstance(np, NodePath)
@@ -27,6 +29,14 @@ class Renderer():
     def pop_root(self) -> NodePath:
         self.render()
         return self.__roots.pop()
+
+    def push_line_thickness(self, thickness: float) -> None:
+        self.__render_lines()
+        self.__thicknesses.append(thickness)
+
+    def pop_line_thickness(self) -> float:
+        self.__render_lines()
+        return self.__thicknesses.pop()
 
     @property
     def line_segs(self) -> LineSegs:

--- a/src/simulator/services/graphics/renderer.py
+++ b/src/simulator/services/graphics/renderer.py
@@ -33,9 +33,11 @@ class Renderer():
     def push_line_thickness(self, thickness: float) -> None:
         self.__render_lines()
         self.__thicknesses.append(thickness)
+        self.__line_segs.set_thickness(thickness)
 
     def pop_line_thickness(self) -> float:
         self.__render_lines()
+        self.__line_segs.set_thickness(self.__thicknesses[-2])
         return self.__thicknesses.pop()
 
     @property

--- a/src/simulator/views/gui/simulator_config.py
+++ b/src/simulator/views/gui/simulator_config.py
@@ -3,6 +3,8 @@ from direct.gui.DirectGui import DirectFrame, DirectButton, DirectLabel, DirectE
 from direct.showbase.ShowBase import ShowBase
 from direct.showbase.DirectObject import DirectObject
 
+import numpy as np
+
 from typing import Tuple, Union, List, Any, Dict, Callable
 import traceback
 
@@ -125,9 +127,9 @@ class SimulatorConfig(DirectObject):
 
     __animations = {
         "None": (0, 0),
-        "Normal": (0.00001, 0),
+        "Normal": (np.finfo(float).eps, 0),
         "Slow": (0.5, 0),
-        "Fast": (0.00001, 20)
+        "Fast": (np.finfo(float).eps, 20)
     }
 
     def __init__(self, services: Services, mouse1_press_callbacks: List[Callable[[], None]]):

--- a/src/simulator/views/gui/simulator_config.py
+++ b/src/simulator/views/gui/simulator_config.py
@@ -147,7 +147,7 @@ class SimulatorConfig(DirectObject):
                 [], {"global_kernel": (CombinedOnlineLSTM, ([], {})), "global_kernel_max_it": 100})),
             "LSTM Bagging": (CombinedOnlineLSTM, CombinedOnlineLSTMTesting, ([], {})),
             "CAE Online LSTM": (
-                OnlineLSTM, BasicTesting, ([], {"load_name": "tile_by_tile_training_uniform_random_fill_3000_block_map_3000_house_3000_model"})),
+                OnlineLSTM, BasicTesting, ([], {"load_name": "caelstm_section_cae_training_house_100_model"})),
             "Online LSTM": (OnlineLSTM, BasicTesting, (
                 [],
                 {"load_name": "tile_by_tile_training_uniform_random_fill_3000_block_map_3000_house_3000_model"})),

--- a/src/simulator/views/gui/simulator_config.py
+++ b/src/simulator/views/gui/simulator_config.py
@@ -127,7 +127,7 @@ class SimulatorConfig(DirectObject):
         "None": (0, 0),
         "Normal": (0.00001, 0),
         "Slow": (0.5, 0),
-        "Fast": (0.16, 20)
+        "Fast": (0.00001, 20)
     }
 
     def __init__(self, services: Services, mouse1_press_callbacks: List[Callable[[], None]]):

--- a/src/simulator/views/map/display/gradient_list_map_display.py
+++ b/src/simulator/views/map/display/gradient_list_map_display.py
@@ -52,7 +52,7 @@ class GradientListMapDisplay(MapDisplay):
 
         self.__cube_colours = {}
 
-    def get_colour(self, val: float) -> Colour:
+    def get_colour(self, val: float) -> Optional[Colour]:
         mag = (val - self.min_val)
 
         d = (self.max_val - self.min_val)
@@ -129,7 +129,9 @@ class GradientListMapDisplay(MapDisplay):
 
     def update_cube(self, p: Point) -> None:
         if p in self.__cube_colours:
-            self._root_view.colour_cube(self.__cube_colours[p])
+            clr = self.__cube_colours[p]
+            if clr is not None:
+                self._root_view.colour_cube(clr)
 
     def get_tracked_data(self) -> List[Tracked]:
         return self.__tracked_data

--- a/src/simulator/views/map/display/gradient_list_map_display.py
+++ b/src/simulator/views/map/display/gradient_list_map_display.py
@@ -53,9 +53,15 @@ class GradientListMapDisplay(MapDisplay):
         self.__cube_colours = {}
 
     def get_colour(self, val: float) -> Colour:
+        mag = (val - self.min_val)
+
         d = (self.max_val - self.min_val)
-        d = d if d != 0 else 1
-        mag = (val - self.min_val) / d
+        if d != 0:
+            mag /= d
+
+        # catch NaN in addition to out-of-bounds
+        if not (mag >= 0 and mag <= 1):
+            return None
 
         cmag = Colour(mag, mag, mag, mag)
         cmin = self.__deduced_min_colour

--- a/src/simulator/views/map/display/online_lstm_map_display.py
+++ b/src/simulator/views/map/display/online_lstm_map_display.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Union, Tuple
+from typing import Union, Tuple, Optional
 
 import torch
 import numpy as np
@@ -11,41 +11,51 @@ from algorithms.configuration.maps.map import Map
 from algorithms.lstm.map_processing import MapProcessing
 from simulator.services.services import Services
 from simulator.views.map.display.map_display import MapDisplay
-from structures import Point, Colour, RED
+from structures import Point, Colour, DynamicColour, RED
 
 
 class OnlineLSTMMapDisplay(MapDisplay):
-    def __init__(self, services: Services, custom_map: Map = None):
+    ray_colour: DynamicColour
+    bearing_colour: DynamicColour
+
+    def __init__(self, services: Services, ray_colour: Optional[DynamicColour] = None, bearing_colour: Optional[DynamicColour] = None, custom_map: Map = None):
         super().__init__(services, z_index=250, custom_map=custom_map)
 
-    def render(self, *discarded) -> None:
-        mp = copy.deepcopy(self._map)
+        self.ray_colour = self._services.state.add_colour("ray", RED) if ray_colour is None else ray_colour
+        self.bearing_colour = self._services.state.add_colour("bearing", Colour(1, 0, 1)) if bearing_colour is None else bearing_colour
 
-        features = MapProcessing.extract_features(mp, [
+    def render(self, *discarded) -> None:
+        self._services.graphics.renderer.push_line_thickness(8)
+
+        features = MapProcessing.extract_features(self._map, [
             "distance_to_goal_normalized",
             "raycast_8_normalized",
             "direction_to_goal_normalized",
             "agent_goal_angle"]
         )
 
-        for (ray, dir) in zip(features["raycast_8_normalized"], mp.ALL_POINTS_MOVE_VECTOR):
-            ray = 50.0 * ray - mp.get_movement_cost(Point(0, 0), dir)
+        rc = self.ray_colour()
+        for (ray, dir) in zip(features["raycast_8_normalized"], self._map.ALL_POINTS_MOVE_VECTOR):
+            ray = 50.0 * ray - self._map.get_movement_cost(Point(0, 0), dir)
             dir = dir.to_tensor() / torch.norm(dir.to_tensor())
-            vec = Point.from_tensor(mp.agent.position.to_tensor() + ray * dir)
-            self.__render_line(mp.agent.position, vec, RED)
+            vec = Point.from_tensor(self._map.agent.position.to_tensor() + ray * dir)
+            self.__render_line(self._map.agent.position, vec, rc)
 
-        self.__render_line(mp.agent.position, mp.goal.position, Colour(1, 0, 1))
-        self.__render_arc(mp.agent.position, mp.goal.position, Colour(1, 0, 1))
+        bc = self.bearing_colour()
+        self.__render_line(self._map.agent.position, self._map.goal.position, bc)
+        self.__render_arc(self._map.agent.position, self._map.goal.position, bc)
+
+        self._services.graphics.renderer.pop_line_thickness()
 
     def __render_arc(self, p1: Point, p2: Point, colour: Colour):
         center = p1
         radius = 1
-        
+
         dir = p2.to_tensor() - p1.to_tensor()
         angle = torch.atan2(dir[1], dir[0])
         angle %= 2 * np.pi
 
         self.get_renderer_view().draw_arc(center, angle, radius=radius, colour=colour)
-        
+
     def __render_line(self, p1: Point, p2: Point, colour: Colour):
         self.get_renderer_view().draw_line(colour, p1, p2)

--- a/src/utility/misc.py
+++ b/src/utility/misc.py
@@ -1,5 +1,5 @@
 import numpy as np
-from direct.stdpy.threading import Condition
+from utility.threading import Condition
 
 from collections.abc import Iterable
 from typing import Tuple, Callable, Optional
@@ -57,15 +57,3 @@ def array_shape(a) -> Tuple[int, ...]:
         return (len(a), *array_shape(a[0]))
     else:
         return (len(a),)
-
-def cond_var_wait_for(cv: Condition, predicate: Callable[[], bool], timeout: Optional[float] = None) -> None:
-    if timeout is None:
-        while not predicate():
-            cv.wait()
-        return True
-    else:
-        start = time.time()
-        while not predicate():
-            if not cv.wait(timeout + start - time.time()):
-                return False
-        return True

--- a/src/utility/threading.py
+++ b/src/utility/threading.py
@@ -1,0 +1,46 @@
+# Here we can choose from a selection of threading
+# modules. That is, we have alternatives from the
+# standard threading module that Panda3D recommends
+# to use for safety, however, they are super-duper
+# slow. Should only enable these when debugging
+# Panda3D code.
+
+_THREADING_TYPE = "STD"
+assert _THREADING_TYPE in ("STD", "DIRECT", "DIRECT2")
+
+if _THREADING_TYPE == "STD":
+    from threading import *
+elif _THREADING_TYPE == "DIRECT":
+    from direct.stdpy.threading import *
+elif _THREADING_TYPE == "DIRECT2":
+    from direct.stdpy.threading2 import *
+
+from typing import Optional, Callable  # noqa: E402
+import time  # noqa: E402
+
+def _cond_var_wait_for_direct(cv: Condition, predicate: Callable[[], bool], timeout: Optional[float] = None) -> bool:
+    if timeout is None:
+        while not predicate():
+            cv.wait()
+        return True
+    else:
+        start = time.time()
+        while not predicate():
+            if not cv.wait(timeout + start - time.time()):
+                return False
+        return True
+
+def _cond_var_wait_for_std(cv: Condition, predicate: Callable[[], bool], timeout: Optional[float] = None) -> bool:
+    return cv.wait_for(predicate, timeout)
+
+
+"""
+cond_var_wait_for()
+
+-> Same behaviour as `cv.wait_for()`, but use to be compatible with all threading modules.
+"""
+
+if _THREADING_TYPE == "STD":
+    cond_var_wait_for = _cond_var_wait_for_std
+else:
+    cond_var_wait_for = _cond_var_wait_for_direct

--- a/src/utility/threading.py
+++ b/src/utility/threading.py
@@ -18,29 +18,26 @@ elif _THREADING_TYPE == "DIRECT2":
 from typing import Optional, Callable  # noqa: E402
 import time  # noqa: E402
 
-def _cond_var_wait_for_direct(cv: Condition, predicate: Callable[[], bool], timeout: Optional[float] = None) -> bool:
-    if timeout is None:
-        while not predicate():
-            cv.wait()
-        return True
-    else:
-        start = time.time()
-        while not predicate():
-            if not cv.wait(timeout + start - time.time()):
-                return False
-        return True
-
-def _cond_var_wait_for_std(cv: Condition, predicate: Callable[[], bool], timeout: Optional[float] = None) -> bool:
-    return cv.wait_for(predicate, timeout)
-
-
-"""
-cond_var_wait_for()
-
--> Same behaviour as `cv.wait_for()`, but use to be compatible with all threading modules.
-"""
-
 if _THREADING_TYPE == "STD":
-    cond_var_wait_for = _cond_var_wait_for_std
+    def cond_var_wait_for(cv: Condition, predicate: Callable[[], bool], timeout: Optional[float] = None) -> bool:
+        """
+        Same behaviour as `cv.wait_for()`, but use to be compatible with all threading modules.
+        """
+
+        return cv.wait_for(predicate, timeout)
 else:
-    cond_var_wait_for = _cond_var_wait_for_direct
+    def cond_var_wait_for(cv: Condition, predicate: Callable[[], bool], timeout: Optional[float] = None) -> bool:
+        """
+        Same behaviour as `cv.wait_for()`, but use to be compatible with all threading modules.
+        """
+
+        if timeout is None:
+            while not predicate():
+                cv.wait()
+            return True
+        else:
+            start = time.time()
+            while not predicate():
+                if not cv.wait(timeout + start - time.time()):
+                    return False
+            return True

--- a/tests/test_graphics/common.py
+++ b/tests/test_graphics/common.py
@@ -41,7 +41,7 @@ def setup(args) -> None:
     pyautogui._pyautogui_x11._display = Xlib.display.Display(os.environ['DISPLAY'])
 
     if not args.no_launch_visualiser:
-        launch_process([sys.executable, os.path.join(SRC_PATH, 'main.py'), '-v', '-Vwindowed-fullscreen', '-Vaudio-library-name=null'],
+        launch_process([sys.executable, os.path.join(SRC_PATH, 'main.py'), '-d', args.debug, '-v', '-Vwindowed-fullscreen', '-Vaudio-library-name=null'],
                        on_kill=lambda _: pyautogui.press('esc'))
 
         pyautogui.moveTo(1, 1)
@@ -56,6 +56,7 @@ def init(no_restore_resources_at_exit: bool = False, no_launch_visualiser: bool 
     parser.add_argument("--no-restore-resources-at-exit", action="store_true", help="do not restore and clean resources folder when test exits")
     parser.add_argument("--no-launch-visualiser", action="store_true", help="do not launch PathBench visualiser")
     parser.add_argument("--no-rm-config-file", action="store_true", help="do not delete PathBench configuration file")
+    parser.add_argument("-d", "--debug", choices=['NONE', 'BASIC', 'LOW', 'MEDIUM', 'HIGH'], default='NONE', help="set the debug level when running, default is none")
 
     if no_restore_resources_at_exit:
         sys.argv.append("--no-restore-resources-at-exit")


### PR DESCRIPTION
- Fully implemented `OnlineLSTMMapDisplay` - e.g. dynamic colours.
- Added ability to quickly toggle to using `direct.stdpy.threading[2]`, which **may** fix an obscure mutex unlocking issue within Panda3D impl. In any case, this is the recommended way of doing multi-threading with Panda3D. Note, graphics tests fail when using the non-built-in threading modules.
- Implemented key frame speed and adjusted simulator config values appropriately.
- Fixed rendering bugs.
- Debug mode configuration in test suite + defaulting to `LOW` for visualiser.