### PR TITLE
Add Child Generator Deque Search algorithm

### DIFF
--- a/src/algorithms/algorithm_manager.py
+++ b/src/algorithms/algorithm_manager.py
@@ -1,4 +1,6 @@
 from algorithms.algorithm import Algorithm
+from algorithms.classic.graph_based.cgds import CGDS
+from algorithms.classic.testing.cgds_testing import CGDSTesting
 from utility.compatibility import HAS_OMPL
 from utility.misc import static_class
 
@@ -86,6 +88,7 @@ class AlgorithmManager():
     def _static_init_(cls):
         cls.builtins = {
             "A*": (AStar, AStarTesting, ([], {})),
+            "Child-Generator-Deque-Search": (CGDS, CGDSTesting, ([], {})),
             "WPN":(WayPointNavigation, WayPointNavigationTesting, ([], {"global_kernel_max_it": 10, "global_kernel": (CombinedOnlineLSTM, ([], {}))})),
             "WPN-view":(WayPointNavigation, WayPointNavigationTesting, ([], {"global_kernel_max_it": 20, "global_kernel": (OnlineLSTM, ([], {"load_name": "tile_by_tile_training_uniform_random_fill_10000_block_map_10000_house_10000_model"}))})),
             "WPN-map": (WayPointNavigation, WayPointNavigationTesting, ([], {"global_kernel_max_it": 20, "global_kernel": (OnlineLSTM, ([], {"load_name": "caelstm_section_lstm_training_uniform_random_fill_10000_block_map_10000_house_10000_model"}))})),

--- a/src/algorithms/classic/graph_based/cgds.py
+++ b/src/algorithms/classic/graph_based/cgds.py
@@ -1,0 +1,166 @@
+from typing import Set, List, Tuple, Optional, Dict
+
+import numpy as np
+
+from algorithms.algorithm import Algorithm
+from algorithms.basic_testing import BasicTesting
+from algorithms.configuration.entities.goal import Goal
+from algorithms.configuration.maps.map import Map
+from algorithms.configuration.maps.ros_map import RosMap
+from simulator.services.services import Services
+from simulator.views.map.display.gradient_list_map_display import GradientListMapDisplay
+from simulator.views.map.display.map_display import MapDisplay
+from simulator.views.map.display.solid_iterable_map_display import SolidIterableMapDisplay
+from structures import Point, Colour, BLUE, DynamicColour
+from structures.factory import gen_set, gen_list
+
+
+"""
+Child-Generator-Deque-Search
+"""
+
+
+class CGDS(Algorithm):
+    class InternalMemory:
+        deque: List[Tuple[Point, float, Point, List[Tuple[Point, float]]]]
+        dequeVisual: List[Tuple[int, Point]]
+        visited: Set[Point]
+        back_pointer: Dict[Point, Optional[Point]]
+        costs: Dict[Point, float]
+        h: Dict[Point, float]
+
+        def __init__(self, services: Services):
+
+            self.deque = gen_list(services)
+            self.dequeVisual = gen_list(services)
+            self.visited = gen_set(services)
+            self.back_pointer = {}
+            self.costs = {}
+            self.h = {}
+
+    mem: InternalMemory
+
+    pq_colour_max: DynamicColour
+    pq_colour_min: DynamicColour
+    visited_colour: DynamicColour
+
+    __map_displays: List[MapDisplay]
+
+    def __init__(self, services: Services, testing: BasicTesting = None):
+        super().__init__(services, testing)
+
+        self.mem = CGDS.InternalMemory(self._services)
+
+        self.pq_colour_max = self._services.state.views.add_colour("explored max", BLUE)
+        self.pq_colour_min = self._services.state.views.add_colour("explored min", Colour(0.27, 0.33, 0.35, 0.2))
+        self.visited_colour = self._services.state.views.add_colour("visited", Colour(0.19, 0.19, 0.2, 0.8))
+
+        self.__map_displays = [SolidIterableMapDisplay(self._services, self.mem.visited, self.visited_colour, z_index=50),
+                               GradientListMapDisplay(self._services, self.mem.dequeVisual, min_colour=self.pq_colour_min,
+                                                  max_colour=self.pq_colour_max, z_index=49, inverted=True)
+                               ]
+
+    def set_display_info(self) -> List[MapDisplay]:
+        """
+        Read super description
+        """
+        return super().set_display_info() + self.__map_displays
+
+    # noinspection PyUnusedLocal
+    # @profile
+    def _find_path_internal(self) -> None:
+        self._init_mem()
+
+        if self._expand():
+            self._follow_back_trace()
+
+    def _init_mem(self) -> None:
+        grid: Map = self._get_grid()
+
+        # push agent
+        self.mem.deque.insert(0, (grid.agent.position, 0.0, None, None))
+        self.mem.back_pointer[grid.agent.position] = None
+
+    def _expand(self) -> bool:
+        grid: Map = self._get_grid()
+
+        while len(self.mem.deque) > 0:
+            parentNode: Point
+            childrenNodes: List[Tuple[Point, float]]
+            parentNode, cost, prev, childrenNodes = self.mem.deque.pop(0)
+
+            if childrenNodes is None:
+                # New parent Node whose children haven't been generated yet
+
+                # Check to see if cost is lower or equal to what has been seen before
+                if parentNode in self.mem.costs and self.mem.costs[parentNode] <= cost:
+                    continue  # skip since cost isn't lower than previously seen
+
+                self.mem.costs[parentNode] = cost
+                self.mem.back_pointer[parentNode] = prev
+                self.mem.visited.add(parentNode)
+
+                # Check if we've reached the goal
+                if grid.is_goal_reached(parentNode):
+                    return True
+
+                # Generate children:
+                children = []
+                for child, idx in grid.get_next_positions_with_move_index(parentNode):
+                    dist = grid.get_movement_cost_from_index(idx)
+                    children.append((self.get_heuristic(child), dist, child))
+                childrenNodes = [(child, dist) for c, dist, child in sorted(children)]
+
+                # Visualisation:
+                listOrder = [node for node, _, _, _ in self.mem.deque]
+                self.mem.dequeVisual.clear()
+                self.mem.dequeVisual.extend([(i, n) for i, n in enumerate(listOrder)])
+
+                self.key_frame()
+
+            if len(childrenNodes) == 0:
+                # No children Nodes so go back and pop a new parent node
+                continue
+            else:
+                # Get the next child and add them to the front of the deque:
+                nextNode, dist = childrenNodes.pop(0)
+                self.mem.deque.insert(0, (nextNode, cost+dist, parentNode, None))
+                # Add parent Node to the back of the queue
+                self.mem.deque.append((parentNode, cost, prev, childrenNodes))
+
+        # Reaching this means the deque is empty but no solutions have been found:
+        return False
+
+    def _follow_back_trace(self):
+        grid: Map = self._get_grid()
+        
+        trace: List[Point] = self.get_back_trace(grid.goal)
+        trace.reverse()
+        for t in trace:
+            self.move_agent(t)
+            if isinstance(grid, RosMap):
+                grid.publish_wp(grid.agent.position)
+            self.key_frame(ignore_key_frame_skip=True)
+
+    def get_back_trace(self, goal: Goal) -> List[Point]:
+        """
+        Follows the back pointer until it gets to the agent position
+        :return: The trace
+        """
+        trace = []
+        pos = goal.position
+        while self.mem.back_pointer[pos] is not None:
+            trace.append(pos)
+            pos = self.mem.back_pointer[pos]
+        return trace
+
+    def get_heuristic(self, pos: Point) -> float:
+        """
+        Returns the euclidean distance from the given position to the goal
+        It does memoization as well
+        :param goal: The goal
+        :param pos: The initial position
+        :return:
+        """
+        self.mem.h.setdefault(pos, np.linalg.norm(np.array(pos) - np.array(self._get_grid().goal.position)))
+        return self.mem.h[pos]

--- a/src/algorithms/classic/testing/cgds_testing.py
+++ b/src/algorithms/classic/testing/cgds_testing.py
@@ -1,0 +1,31 @@
+from typing import Dict, Any
+
+from algorithms.basic_testing import BasicTesting
+from simulator.services.debug import DebugLevel
+
+
+class CGDSTesting(BasicTesting):
+    """
+    Testing for CGDS
+    """
+
+    def get_results(self) -> Dict[str, Any]:
+        """
+        Read super description
+        """
+        res: Dict[str, Any] = super().get_results()
+        res["active_space"] = BasicTesting.get_occupancy_percentage_size(self._services.algorithm.map.size,
+                                                                   len(self._services.algorithm.instance.mem.deque))
+        res["search_space"] = BasicTesting.get_occupancy_percentage_size(self._services.algorithm.map.size,
+                                                                         len(self._services.algorithm.instance.mem.visited))
+        return res
+
+    def print_results(self) -> None:
+        """
+        Read super description
+        """
+        super().print_results()
+        results: Dict[str, Any] = self.get_results()
+        self._services.debug.write("Search space percentage: {0:.2f}%".format(results["search_space"]), DebugLevel.BASIC)
+        self._services.debug.write("Active search space percentage: {0:.2f}%".format(results["active_space"]), DebugLevel.BASIC)
+

--- a/src/run_trainer.py
+++ b/src/run_trainer.py
@@ -1,4 +1,5 @@
-
+from algorithms.classic.graph_based.cgds import CGDS
+from algorithms.classic.testing.cgds_testing import CGDSTesting
 from main import MainRunner
 from typing import Tuple, Callable, Type, List, Optional, Dict, Any, Union
 from algorithms.algorithm import Algorithm
@@ -63,6 +64,7 @@ maps = MapManager.builtins
 
 algorithms = {
     "A*": (AStar, AStarTesting, ([], {})),
+    "Child-Generator-Deque-Search": (CGDS, CGDSTesting, ([], {})),
     "Global Way-point LSTM": (WayPointNavigation, WayPointNavigationTesting, ([], {"global_kernel": (CombinedOnlineLSTM, ([], {})), "global_kernel_max_it": 100})),
     "LSTM Bagging": (CombinedOnlineLSTM, CombinedOnlineLSTMTesting, ([], {})),
     "CAE Online LSTM": (OnlineLSTM, BasicTesting, ([], {"load_name": "caelstm_section_lstm_training_block_map_10000_model"})),


### PR DESCRIPTION
Adds the 'Child Generator Deque Search' algorithm to PathBench.
Based on algorithm in: https://arxiv.org/abs/2101.08715 

In each iteration of the algorithm the front of a deque is polled for a node (coordinate, cost, parent node, child-generator):   
- If the node hasn't been visited before:
  - The node is checked to see if it is at the goal position, if so return the path.
  - If the node has the lowest cost so far for its position record the cost and parent node into maps: coordinate -> cost, and coordinate -> previous-coordinate
  - A 'generator function' (implemented as a list for simplicity)  is produced that produces gets the child nodes from this current node. The child generator function produces the child nodes ordered by closest euclidean distance to goal
- If the child-generator it is empty skip to the next iteration.
- The child-generator is polled, put the child node at the front of the deque (child-coordinates, cost+movement, current node, None) and the parent node (along with child generator function) at the back.