### PR TITLE
nptyping version downgrade to avoid code refactoring 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 numpy
 matplotlib
-nptyping
+nptyping==1.4.4
 panda3d
 pandas
 sklearn


### PR DESCRIPTION
Currently, when new users pull the repository and create a venv, the requirements.txt file will install nptyping v2.0+, which seems to cause the following issue:

 ```
raise InvalidArgumentsError(
nptyping.error.InvalidArgumentsError: Unexpected argument '(typing.Any, typing.Any, typing.Any)', expecting Shape[<ShapeExpression>] or Literal[<ShapeExpression>] or typing.Any.
```
The syntax seems to have changed. This problem is dotted throughout the code.

A **temporary** fix is to simply peg the version of nptyping to 1.4.4, and avoid this problem at the moment.
